### PR TITLE
Replace MathJax CDN with current HTTPS URL to fix potential mixed content and deprecation

### DIFF
--- a/_includes/mathjax.html
+++ b/_includes/mathjax.html
@@ -7,17 +7,7 @@
     }
   });
 </script>
-<script
-  type="text/javascript"
-  charset="utf-8"
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
->
-</script>
-<script
-  type="text/javascript"
-  charset="utf-8"
-  src="https://vincenttam.github.io/javascripts/MathJaxLocal.js"
->
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" async>
 </script>
 {% endif %}
 


### PR DESCRIPTION
The MathJax CDN URL in `_includes/mathjax.html` uses `http://cdn.mathjax.org` which is deprecated and can cause mixed content warnings on HTTPS sites. Update to the current recommended HTTPS URL from jsDelivr or Cloudflare CDN. Also remove the redundant MathJaxLocal.js script since it's an unofficial fork that may not be maintained.